### PR TITLE
Add support for other Darwin-based systems

### DIFF
--- a/src/photon/macos/core.d
+++ b/src/photon/macos/core.d
@@ -1,5 +1,10 @@
 module photon.macos.core;
-version(OSX):
+version(OSX) version = Darwin;
+else version(iOS) version = Darwin;
+else version(TVOS) version = Darwin;
+else version(WatchOS) version = Darwin;
+else version(VisionOS) version = Darwin;
+version(Darwin):
 package(photon):
 
 import std.stdio;

--- a/src/photon/macos/support.d
+++ b/src/photon/macos/support.d
@@ -1,5 +1,10 @@
 module photon.macos.support;
-version(OSX):
+version(OSX) version = Darwin;
+else version(iOS) version = Darwin;
+else version(TVOS) version = Darwin;
+else version(WatchOS) version = Darwin;
+else version(VisionOS) version = Darwin;
+version(Darwin):
 import core.sys.posix.unistd;
 import core.stdc.errno;
 import core.stdc.stdlib;

--- a/src/photon/package.d
+++ b/src/photon/package.d
@@ -65,9 +65,15 @@ import std.meta;
 
 import photon.ds.ring_queue;
 
+version(OSX) version = Darwin;
+else version(iOS) version = Darwin;
+else version(TVOS) version = Darwin;
+else version(WatchOS) version = Darwin;
+else version(VisionOS) version = Darwin;
+
 version(Windows) public import photon.windows.core;
 else version(linux) public import photon.linux.core;
-else version(OSX) public import photon.macos.core;
+else version(Darwin) public import photon.macos.core;
 else version(FreeBSD) public import photon.freebsd.core;
 else static assert(false, "Target OS not supported by Photon yet!");
 

--- a/src/photon/support.d
+++ b/src/photon/support.d
@@ -1,6 +1,12 @@
 module photon.support;
 
+version(OSX) version = Darwin;
+else version(iOS) version = Darwin;
+else version(TVOS) version = Darwin;
+else version(WatchOS) version = Darwin;
+else version(VisionOS) version = Darwin;
+
 version(linux) public import photon.linux.support;
 else version(FreeBSD) public import photon.freebsd.support;
-else version(OSX) public import photon.macos.support;
+else version(Darwin) public import photon.macos.support;
 else version(Windows) public import photon.windows.support;

--- a/src/photon/threadpool.d
+++ b/src/photon/threadpool.d
@@ -7,10 +7,16 @@ import std.random;
 
 import photon.ds.intrusive_queue;
 
+version(OSX) version = Darwin;
+else version(iOS) version = Darwin;
+else version(TVOS) version = Darwin;
+else version(WatchOS) version = Darwin;
+else version(VisionOS) version = Darwin;
+
 // TODO: time to factor out common parts of schedulers?
 version(linux) public import photon.linux.core;
 else version(FreeBSD) public import photon.freebsd.core;
-else version(OSX) public import photon.macos.core;
+else version(Darwin) public import photon.macos.core;
 else version(Windows) public import photon.windows.core;
 
 


### PR DESCRIPTION
Seemingly, current the macOS implementation of Photon never uses any symbols that would stop it from working on all Darwin-based systems.

Fixes #36.