### PR TITLE
Handle plain send too + a few optimizations

### DIFF
--- a/src/photon/linux/core.d
+++ b/src/photon/linux/core.d
@@ -255,6 +255,9 @@ public void startloop() nothrow @trusted
     ssize_t size = ((fdMax * Descriptor.sizeof) + pageSize-1) & ~(pageSize-1);
     descriptors = (cast(shared(Descriptor*)) mmap(null, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0))[0..fdMax];
     checked(cast(ssize_t)descriptors.ptr, "mmap failed");
+    size = ((fdMax * DescriptorState.sizeof) + pageSize-1) & ~(pageSize-1);
+    descriptorStates = (cast(shared(DescriptorState*)) mmap(null, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0))[0..fdMax];
+    checked(cast(ssize_t)descriptorStates.ptr, "mmap failed");
     scheds = new SchedulerBlock[threads];
     foreach(ref sched; scheds) {
         sched.queue = IntrusiveQueue!(FiberExt, RawEvent)(RawEvent(0));
@@ -284,7 +287,7 @@ void processEventsEntry(size_t numSched, Duration timeout)
         }
         else {
             auto descriptor = descriptors.ptr + fd;
-            if (descriptor.state == DescriptorState.NONBLOCKING) {
+            if (descriptorStates[fd] == DescriptorState.NONBLOCKING) {
                 if (events[n].events & EPOLLIN) {
                     auto readers = &descriptor.readers;
                     readers.lock();
@@ -346,7 +349,7 @@ enum SyscallKind { accept, read, write, connect }
 void interceptFd(Fcntl needsFcntl)(int fd) nothrow {
     logf("Hit interceptFD");
     if (fd < 0 || fd >= descriptors.length) return;
-    if (cas(&descriptors[fd].state, DescriptorState.NOT_INITED, DescriptorState.INITIALIZING)) {
+    if (cas(&descriptorStates[fd], DescriptorState.NOT_INITED, DescriptorState.INITIALIZING)) {
         logf("First use, registering fd = %s", fd);
         static if(needsFcntl == Fcntl.explicit) {
             int flags = fcntl(fd, F_GETFL, 0);
@@ -359,14 +362,14 @@ void interceptFd(Fcntl needsFcntl)(int fd) nothrow {
         size_t n = currentFiber !is null ? currentFiber.numScheduler : 0;
         if (epoll_ctl(scheds[n].event_loop, EPOLL_CTL_ADD, fd, &event) < 0 && errno == EPERM) {
             logf("isSocket = false FD = %s", fd);
-            descriptors[fd].state = DescriptorState.THREADPOOL;
+            descriptorStates[fd] = DescriptorState.THREADPOOL;
         }
         else {
             logf("isSocket = true FD = %s", fd);
-            descriptors[fd].state = DescriptorState.NONBLOCKING;
+            descriptorStates[fd] = DescriptorState.NONBLOCKING;
         }
     }
-    while(descriptors[fd].state == DescriptorState.INITIALIZING) {}
+    while(descriptorStates[fd] == DescriptorState.INITIALIZING) {}
 }
 
 // ======================================================================================

--- a/src/photon/macos/core.d
+++ b/src/photon/macos/core.d
@@ -274,6 +274,10 @@ public void startloop()
     fdMax = fdMax > 2^^24 ? 2^^24 : fdMax;
     ssize_t size = ((fdMax * Descriptor.sizeof) + pageSize-1) & ~(pageSize-1);
     descriptors = (cast(shared(Descriptor*)) mmap(null, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0))[0..fdMax];
+    checked(cast(ssize_t)descriptors.ptr, "mmap failed");
+    size = ((fdMax * DescriptorState.sizeof) + pageSize-1) & ~(pageSize-1);
+    descriptorStates = (cast(shared(DescriptorState*)) mmap(null, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0))[0..fdMax];
+    checked(cast(ssize_t)descriptorStates.ptr, "mmap failed");
     scheds = new SchedulerBlock[threads];
     foreach(ref sched; scheds) {
         sched.queue = IntrusiveQueue!(FiberExt, RawEvent)(RawEvent(0));
@@ -348,7 +352,7 @@ enum SyscallKind { accept, read, write, connect }
 void interceptFd(Fcntl needsFcntl)(int fd) nothrow {
     logf("Hit interceptFD");
     if (fd < 0 || fd >= descriptors.length) return;
-    if (cas(&descriptors[fd].state, DescriptorState.NOT_INITED, DescriptorState.INITIALIZING)) {
+    if (cas(&descriptorStates[fd], DescriptorState.NOT_INITED, DescriptorState.INITIALIZING)) {
         logf("First use, registering fd = %s", fd);
         static if(needsFcntl == Fcntl.explicit) {
             int flags = fcntl(fd, F_GETFL, 0);
@@ -363,9 +367,9 @@ void interceptFd(Fcntl needsFcntl)(int fd) nothrow {
         ke[1].flags = ke[0].flags = EV_ADD | EV_ENABLE | EV_CLEAR;
         int ret = kevent(getCurrentKqueue, ke.ptr, 2, null, 0, null);
         if (ret < 0) {
-            descriptors[fd].state = DescriptorState.THREADPOOL;
+            descriptorStates[fd] = DescriptorState.THREADPOOL;
         } else {
-            descriptors[fd].state = DescriptorState.NONBLOCKING;
+            descriptorStates[fd] = DescriptorState.NONBLOCKING;
         }
     }
 }

--- a/src/photon/reactor.d
+++ b/src/photon/reactor.d
@@ -158,7 +158,7 @@ enum DescriptorState: uint {
     THREADPOOL
 }
 
-struct FdWaiters(T, bool trace=false) {
+struct FdWaiters(T) {
     private LinkedList!(AwaitingFiber*, "next", "prev") waiters;
     T state;
     private SpinLock splk;
@@ -210,9 +210,9 @@ nothrow:
 // list of awaiting fibers
 shared struct Descriptor {
     FdWaiters!ReaderState readers;
-    FdWaiters!(WriterState, true) writers;
-    DescriptorState state;
+    FdWaiters!WriterState writers;
 }
+static assert (Descriptor.sizeof == 64);
 
 enum TIMER_NUM_BINS = 256;
 enum TIMER_NUM_LEVELS = 4;
@@ -226,6 +226,7 @@ FiberExt currentFiber;
 shared int alive; // count of non-terminated Fibers
 shared SchedulerBlock[] scheds; // per core scheduler data, notably run queue
 shared Descriptor[] descriptors;
+shared DescriptorState[] descriptorStates;
 
 CascadingTimeQueue!(TimedFiber*, TIMER_NUM_BINS, TIMER_NUM_LEVELS, true) timeQueue; // thread-local
 
@@ -400,6 +401,26 @@ if (isAwaitable!(Awaitable)) {
     assert(0);
 }
 
+ssize_t syscallOffload(T...)(size_t ident, int fd, T args) nothrow {
+    pragma(inline, false);
+    auto result = offload(() {
+        auto ret = __syscall(ident, fd, args);
+        if (ret < 0) {
+            return -errno;
+        }
+        else {
+            return ret;
+        }
+    });
+    if (result < 0) {
+        errno = cast(int)-result;
+        return -1;
+    }
+    else {
+        return result;
+    }
+}
+
 ssize_t universalSyscall(size_t ident, string name, SyscallKind kind, Fcntl fcntlStyle, ssize_t ERR, T...)
                         (int fd, T args) nothrow {
     if (currentFiber is null) {
@@ -410,24 +431,9 @@ ssize_t universalSyscall(size_t ident, string name, SyscallKind kind, Fcntl fcnt
         logf("HOOKED %s FD=%d", name, fd);
         interceptFd!(fcntlStyle)(fd);
         shared(Descriptor)* descriptor = descriptors.ptr + fd;
-        if (atomicLoad(descriptor.state) == DescriptorState.THREADPOOL) {
+        if (atomicLoad(descriptorStates[fd]) == DescriptorState.THREADPOOL) {
             logf("%s syscall THREADPOLL FD=%d", name, fd);
-            auto result = offload(() {
-                auto ret = __syscall(ident, fd, args);
-                if (ret < 0) {
-                    return -errno;
-                }
-                else {
-                    return ret;
-                }
-            });
-            if (result < 0) {
-                errno = cast(int)-result;
-                return -1;
-            }
-            else {
-                return result;
-            }
+            return syscallOffload(ident, fd, args);
         }
     L_start:
         FiberExt fiber = currentFiber;
@@ -578,7 +584,7 @@ void deregisterFd(int fd) nothrow {
         descriptor.writers.lock();
         descriptor.writers.state = WriterState.READY;
         descriptor.writers.broadcast(choice, fd);
-        atomicStore(descriptor.state, DescriptorState.NOT_INITED);
+        atomicStore(descriptorStates[fd], DescriptorState.NOT_INITED);
     }
 }
 
@@ -617,6 +623,12 @@ extern(C) ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
 {
     return universalSyscall!(SYS_SENDTO, "sendto", SyscallKind.write, Fcntl.explicit, EWOULDBLOCK)
         (sockfd, cast(size_t) buf, len, flags, cast(size_t) dest_addr, cast(size_t) addrlen);
+}
+
+extern(C) ssize_t send(int sockfd, const void *buf, size_t len, int flags)
+{
+    return universalSyscall!(SYS_SENDTO, "sendto", SyscallKind.write, Fcntl.explicit, EWOULDBLOCK)
+        (sockfd, cast(size_t) buf, len, flags, null, 0);
 }
 
 extern(C) ssize_t recv(int sockfd, void *buf, size_t len, int flags) nothrow {


### PR DESCRIPTION
universalSyscall no longer allocates closure on hot path.
Split state and descriptor waiters so that waiters occupy exactly one cache line.