### PR TITLE
Keep track of closed sockets to avoid mistreating events

### DIFF
--- a/examples/join.d
+++ b/examples/join.d
@@ -35,5 +35,9 @@ void main() {
             assert(e.msg == "Boom!");
         }
     });
+    auto task3 = go({
+        task1.joinUninterruptible();
+        assert(flag == 1);
+    });
     runScheduler();
 }

--- a/src/photon/joiners.d
+++ b/src/photon/joiners.d
@@ -1,0 +1,63 @@
+module photon.joiners;
+
+import photon.core;
+
+class FiberJoiners {
+    ThreadInfo tidInfo;
+    bool terminated;
+    Throwable thr;
+    SpinLock joinLock;
+    FiberExt joiners;
+
+    void join() shared {
+        this.unshared.join();
+    }
+
+    void join() {
+        assert(currentFiber);
+        bool suspend = false;
+        joinLock.lock();
+        if (!terminated) {
+            if (joiners) {
+                currentFiber.next = joiners;
+            }
+            joiners = currentFiber;
+            suspend = true;
+        }
+        joinLock.unlock();
+        if (suspend) FiberExt.yield();
+        if (thr) throw thr;
+    }
+
+    void joinNothrow() nothrow shared {
+        this.unshared.joinNothrow();
+    }
+
+    void joinNothrow() nothrow {
+        assert(currentFiber);
+        bool suspend = false;
+        joinLock.lock();
+        if (!terminated) {
+            if (joiners) {
+                currentFiber.next = joiners;
+            }
+            joiners = currentFiber;
+            suspend = true;
+        }
+        joinLock.unlock();
+        if (suspend) FiberExt.yield();
+        // skips rethrowing exception
+    }
+
+    void wakeUpJoiners(size_t numSched) {
+        joinLock.lock();
+        terminated = true;
+        FiberExt f = joiners;
+        while (f) {
+            joiners.schedule(numSched, WAKE_JOIN);
+            f = f.next;
+        }
+        joiners = null;
+        joinLock.unlock();
+    }
+}

--- a/src/photon/package.d
+++ b/src/photon/package.d
@@ -71,6 +71,7 @@ import mecca.containers.lists;
 public import photon.core;
 public import photon.threadpool;
 public import photon.task;
+public import photon.exceptions;
 
 version(PhotonDocs) {
 

--- a/src/photon/reactor.d
+++ b/src/photon/reactor.d
@@ -84,7 +84,7 @@ class FiberJoiners {
             suspend = true;
         }
         joinLock.unlock();
-        if (suspend) yield();
+        if (suspend) currentFiber.yield();
         if (thr) throw thr;
     }
 
@@ -101,7 +101,7 @@ class FiberJoiners {
             suspend = true;
         }
         joinLock.unlock();
-        if (suspend) yield();
+        if (suspend) currentFiber.yield();
         // skips rethrowing exception
     }
 

--- a/src/photon/reactor.d
+++ b/src/photon/reactor.d
@@ -131,11 +131,13 @@ class FiberExt : Fiber {
     this(void function() fn, uint numSched) nothrow {
         super(fn, 2<<20);
         numScheduler = numSched;
+        joiners = new FiberJoiners;
     }
 
     this(void delegate() dg, uint numSched) nothrow {
         super(dg, 2<<20);
         numScheduler = numSched;
+        joiners = new FiberJoiners;
     }
 
     void schedule(size_t nsched, int wakeFd) nothrow

--- a/src/photon/reactor.d
+++ b/src/photon/reactor.d
@@ -47,6 +47,7 @@ import photon.ds.common;
 import photon.ds.intrusive_queue;
 import photon.threadpool;
 import photon.task;
+import photon.joiners;
 
 import mecca.time_queue;
 import mecca.containers.lists;
@@ -61,58 +62,6 @@ struct AwaitingFiber {
         if (f !is null) {
             f.schedule(sched, wakeFd);
         }
-    }
-}
-
-class FiberJoiners {
-    ThreadInfo tidInfo;
-    bool terminated;
-    Throwable thr;
-    SpinLock joinLock;
-    FiberExt joiners;
-
-    void join() shared {
-        this.unshared.join();
-    }
-
-    void join() {
-        assert(currentFiber);
-        bool suspend = false;
-        joinLock.lock();
-        if (!terminated) {
-            joiners = currentFiber;
-            suspend = true;
-        }
-        joinLock.unlock();
-        if (suspend) currentFiber.yield();
-        if (thr) throw thr;
-    }
-
-    void joinNothrow() nothrow shared {
-        this.unshared.joinNothrow();
-    }
-
-    void joinNothrow() nothrow {
-        assert(currentFiber);
-        bool suspend = false;
-        joinLock.lock();
-        if (!terminated) {
-            joiners = currentFiber;
-            suspend = true;
-        }
-        joinLock.unlock();
-        if (suspend) currentFiber.yield();
-        // skips rethrowing exception
-    }
-
-    void wakeUpJoiners(size_t numSched) {
-        joinLock.lock();
-        terminated = true;
-        FiberExt f = joiners;
-        if (joiners) {
-            joiners.schedule(numSched, WAKE_JOIN);
-        }
-        joinLock.unlock();
     }
 }
 

--- a/src/photon/reactor.d
+++ b/src/photon/reactor.d
@@ -380,7 +380,7 @@ public Task go(void delegate() func) nothrow @trusted  {
     logf("Assigned %x -> %d / %d scheduler", cast(void*)f, choice, scheds.length);
     f.schedule(choice, WAKE_TRIGGER);
     notifyEventloop(choice);
-    return Task(f);
+    return Task(f.joiners);
 }
 
 /// Convenience overload for goOnSameThread that accepts functions 
@@ -398,7 +398,7 @@ public Task goOnSameThread(void delegate() func) nothrow @trusted {
     logf("Assigned %x -> %d / %d scheduler", cast(void*)f, choice, scheds.length);
     f.schedule(choice, WAKE_TRIGGER);
     notifyEventloop(choice);
-    return Task(f);
+    return Task(f.joiners);
 }
 
 /// Convenience overload for goOnAllThreads that accepts functions 

--- a/src/photon/reactor.d
+++ b/src/photon/reactor.d
@@ -64,14 +64,63 @@ struct AwaitingFiber {
     }
 }
 
+class FiberJoiners {
+    ThreadInfo tidInfo;
+    bool terminated;
+    Throwable thr;
+    SpinLock joinLock;
+    FiberExt joiners;
+
+    void join() shared {
+        this.unshared.join();
+    }
+
+    void join() {
+        assert(currentFiber);
+        bool suspend = false;
+        joinLock.lock();
+        if (!terminated) {
+            joiners = currentFiber;
+            suspend = true;
+        }
+        joinLock.unlock();
+        if (suspend) yield();
+        if (thr) throw thr;
+    }
+
+    void joinNothrow() nothrow shared {
+        this.unshared.joinNothrow();
+    }
+
+    void joinNothrow() nothrow {
+        assert(currentFiber);
+        bool suspend = false;
+        joinLock.lock();
+        if (!terminated) {
+            joiners = currentFiber;
+            suspend = true;
+        }
+        joinLock.unlock();
+        if (suspend) yield();
+        // skips rethrowing exception
+    }
+
+    void wakeUpJoiners(size_t numSched) {
+        joinLock.lock();
+        terminated = true;
+        FiberExt f = joiners;
+        if (joiners) {
+            joiners.schedule(numSched, WAKE_JOIN);
+        }
+        joinLock.unlock();
+    }
+}
+
 class FiberExt : Fiber { 
     FiberExt next;
     uint numScheduler;
     int wakeFd; // recieves fd that woken us up
-    ThreadInfo tidInfo;
-    SpinLock joinLock;
-    FiberExt joiners;
-    Throwable thr;
+    FiberJoiners joiners;
     struct FlsEntry {
         void* pointer;
         void function(void*) dtor;
@@ -96,49 +145,6 @@ class FiberExt : Fiber {
         if (nsched != numScheduler) {
             notifyEventloop(numScheduler);
         }
-    }
-
-    void join() shared {
-        this.unshared.join();
-    }
-
-    void join() {
-        assert(currentFiber);
-        bool suspend = false;
-        joinLock.lock();
-        if (state != Fiber.State.TERM) {
-            joiners = currentFiber;
-            suspend = true;
-        }
-        joinLock.unlock();
-        if (suspend) yield();
-        if (thr) throw thr;
-    }
-
-    void joinNothrow() nothrow shared {
-        this.unshared.joinNothrow();
-    }
-
-    void joinNothrow() nothrow {
-        assert(currentFiber);
-        bool suspend = false;
-        joinLock.lock();
-        if (state != Fiber.State.TERM) {
-            joiners = currentFiber;
-            suspend = true;
-        }
-        joinLock.unlock();
-        if (suspend) yield();
-        // skips rethrowing exception
-    }
-
-    void wakeUpJoiners(size_t numSched) {
-        joinLock.lock();
-        FiberExt f = joiners;
-        if (joiners) {
-            joiners.schedule(numSched, WAKE_JOIN);
-        }
-        joinLock.unlock();
     }
 
     static size_t flsAlloc() nothrow {
@@ -304,7 +310,10 @@ package(photon) void schedulerEntry(size_t n)
             }
         }
         logf("Fiber %s terminated", cast(void*)f);
-        f.wakeUpJoiners(n);
+        auto joiners = f.joiners;
+        destroy(f);
+        joiners.wakeUpJoiners(n);
+
     }
 
     shared SchedulerBlock* sched = scheds.ptr + n;
@@ -331,7 +340,7 @@ package(photon) void schedulerEntry(size_t n)
                     }
                 }
                 catch (Exception e) {
-                    f.thr = e;
+                    f.joiners.thr = e;
                     onTermination(f);
                 }
                 catch (Throwable e) {

--- a/src/photon/task.d
+++ b/src/photon/task.d
@@ -11,12 +11,12 @@ import std.concurrency;
 */
 struct Task {
 package:
-    shared FiberExt _fiber;
+    shared FiberJoiners _joiners;
     static ThreadInfo s_tidInfo;
 	
-    this(FiberExt fiber)
+    this(FiberJoiners joiners)
 	@trusted nothrow {
-		this._fiber = cast(shared)fiber;
+		this._joiners = cast(shared)joiners;
 	}
 
 public:
@@ -25,29 +25,26 @@ public:
 	//       move constructor
 	this()(Task other)
 	@safe nothrow {
-		_fiber = other._fiber;
+		_joiners = other._joiners;
 	}
 
 	/** Returns the Task instance belonging to the calling task.
 	*/
 	static Task getThis() @safe nothrow
 	{
-		return Task(currentFiber);
+		return Task(currentFiber.joiners);
 	}
 
 	nothrow {
-		package @property FiberExt taskFiber() @system { return cast()_fiber; }
-		@property FiberExt fiber() @system { return cast()this._fiber; }
-
 		/** Determines if the task is still running or scheduled to be run.
 		*/
 		@property bool running()
 		const @trusted {
-			return _fiber.unshared.state != Fiber.State.TERM;
+			return !_joiners.terminated;
 		}
 
-		@property ref ThreadInfo tidInfo() @system { return _fiber ? cast()_fiber.tidInfo : s_tidInfo; } // FIXME: this is not thread safe!
-		@property ref const(ThreadInfo) tidInfo() const @system { return _fiber ? cast()_fiber.tidInfo : s_tidInfo; } // FIXME: this is not thread safe!
+		@property ref ThreadInfo tidInfo() @system { return _joiners ? cast()_joiners.tidInfo : s_tidInfo; } // FIXME: this is not thread safe!
+		@property ref const(ThreadInfo) tidInfo() const @system { return _joiners ? cast()_joiners.tidInfo : s_tidInfo; } // FIXME: this is not thread safe!
 
 		/** Gets the `Tid` associated with this task for use with
 			`std.concurrency`.
@@ -60,20 +57,20 @@ public:
 	T opCast(T)() const @safe nothrow if (is(T == bool)) { return _fiber !is null; }
 	T opCast(T)() const shared @safe nothrow if (is(T == bool)) { return _fiber !is null; }
 
-	void join() @trusted { if (_fiber) _fiber.join(); }
-	void joinUninterruptible() @trusted nothrow { if (_fiber) _fiber.joinNothrow(); }
+	void join() @trusted { if (_joiners) _joiners.unshared.join(); }
+	void joinUninterruptible() @trusted nothrow { if (_joiners) _joiners.unshared.joinNothrow(); }
 	void interrupt() @trusted nothrow { 
         //noop
     }
 
 	bool opEquals(scope ref const(Task) other) const @safe nothrow {
-		return _fiber is other._fiber;
+		return _joiners is other._joiners;
 	}
 	bool opEquals(scope const(Task) other) const @safe nothrow {
-		return _fiber is other._fiber;
+		return _joiners is other._joiners;
 	}
 	bool opEquals(scope shared(const(Task)) other) const shared @safe nothrow {
-		return _fiber is other._fiber;
+		return _joiners is other._joiners;
 	}
 }
 

--- a/src/photon/task.d
+++ b/src/photon/task.d
@@ -54,11 +54,11 @@ public:
 		@property const(Tid) tid() const @trusted { return tidInfo.ident; }
 	}
 
-	T opCast(T)() const @safe nothrow if (is(T == bool)) { return _fiber !is null; }
-	T opCast(T)() const shared @safe nothrow if (is(T == bool)) { return _fiber !is null; }
+	T opCast(T)() const @safe nothrow if (is(T == bool)) { return _joiners !is null; }
+	T opCast(T)() const shared @safe nothrow if (is(T == bool)) { return _joiners !is null; }
 
-	void join() @trusted { if (_joiners) _joiners.unshared.join(); }
-	void joinUninterruptible() @trusted nothrow { if (_joiners) _joiners.unshared.joinNothrow(); }
+	void join() @trusted { if (_joiners) _joiners.join(); }
+	void joinUninterruptible() @trusted nothrow { if (_joiners) _joiners.joinNothrow(); }
 	void interrupt() @trusted nothrow { 
         //noop
     }

--- a/src/photon/windows/core.d
+++ b/src/photon/windows/core.d
@@ -28,6 +28,7 @@ import photon.ds.common;
 import photon.ds.intrusive_queue;
 import photon.windows.support;
 import photon.task;
+import photon.joiners;
 import photon.threadpool;
 import std.file;
 
@@ -327,58 +328,6 @@ struct SchedulerBlock {
     HANDLE iocp; // IO Completion port
 }
 static assert(SchedulerBlock.sizeof == 64);
-
-class FiberJoiners {
-    ThreadInfo tidInfo;
-    bool terminated;
-    Throwable thr;
-    SpinLock joinLock;
-    FiberExt joiners;
-
-    void join() shared {
-        this.unshared.join();
-    }
-
-    void join() {
-        assert(currentFiber);
-        bool suspend = false;
-        joinLock.lock();
-        if (!terminated) {
-            joiners = currentFiber;
-            suspend = true;
-        }
-        joinLock.unlock();
-        if (suspend) yield();
-        if (thr) throw thr;
-    }
-
-    void joinNothrow() nothrow shared {
-        this.unshared.joinNothrow();
-    }
-
-    void joinNothrow() nothrow {
-        assert(currentFiber);
-        bool suspend = false;
-        joinLock.lock();
-        if (!terminated) {
-            joiners = currentFiber;
-            suspend = true;
-        }
-        joinLock.unlock();
-        if (suspend) yield();
-        // skips rethrowing exception
-    }
-
-    void wakeUpJoiners(size_t numSched) {
-        joinLock.lock();
-        terminated = true;
-        FiberExt f = joiners;
-        if (joiners) {
-            joiners.schedule(numSched, WAKE_JOIN);
-        }
-        joinLock.unlock();
-    }
-}
 
 class FiberExt : Fiber { 
     FiberExt next;

--- a/src/photon/windows/core.d
+++ b/src/photon/windows/core.d
@@ -328,45 +328,12 @@ struct SchedulerBlock {
 }
 static assert(SchedulerBlock.sizeof == 64);
 
-class FiberExt : Fiber { 
-    FiberExt next;
-    FiberExt back;
+class FiberJoiners {
     ThreadInfo tidInfo;
-    uint numScheduler;
-    int bytesTransfered;
-    int wakeFd;
+    bool terminated;
     Throwable thr;
-    size_t fastPathSkip;
-    size_t fastPathSkipAck;
     SpinLock joinLock;
     FiberExt joiners;
-    struct FlsEntry {
-        void* pointer;
-        void function(void*) dtor;
-    }
-    FlsEntry[] fls;
-    static size_t flsOffset;
-
-    enum PAGESIZE = 4096;
-    
-    this(void function() fn, uint numSched) nothrow {
-        super(fn, 2<<20);
-        numScheduler = numSched;
-    }
-
-    this(void delegate() dg, uint numSched) nothrow {
-        super(dg, 2<<20);
-        numScheduler = numSched;
-    }
-
-    void schedule(size_t from, int wake) nothrow
-    {
-        wakeFd = wake;
-        scheds[numScheduler].queue.push(this);
-        if (from != numScheduler) {
-            notifyEventloop(numScheduler);
-        }
-    }
 
     void join() shared {
         this.unshared.join();
@@ -376,7 +343,7 @@ class FiberExt : Fiber {
         assert(currentFiber);
         bool suspend = false;
         joinLock.lock();
-        if (state != Fiber.State.TERM) {
+        if (!terminated) {
             joiners = currentFiber;
             suspend = true;
         }
@@ -393,7 +360,7 @@ class FiberExt : Fiber {
         assert(currentFiber);
         bool suspend = false;
         joinLock.lock();
-        if (state != Fiber.State.TERM) {
+        if (!terminated) {
             joiners = currentFiber;
             suspend = true;
         }
@@ -404,11 +371,49 @@ class FiberExt : Fiber {
 
     void wakeUpJoiners(size_t numSched) {
         joinLock.lock();
+        terminated = true;
         FiberExt f = joiners;
         if (joiners) {
             joiners.schedule(numSched, WAKE_JOIN);
         }
         joinLock.unlock();
+    }
+}
+
+class FiberExt : Fiber { 
+    FiberExt next;
+    FiberExt back;
+    uint numScheduler;
+    int bytesTransfered;
+    int wakeFd;
+    FiberJoiners joiners;
+    struct FlsEntry {
+        void* pointer;
+        void function(void*) dtor;
+    }
+    FlsEntry[] fls;
+    static size_t flsOffset;
+
+    enum PAGESIZE = 4096;
+    
+    this(void function() fn, uint numSched) nothrow {
+        super(fn, 2<<20);
+        numScheduler = numSched;
+        joiners = new FiberJoiners;
+    }
+
+    this(void delegate() dg, uint numSched) nothrow {
+        super(dg, 2<<20);
+        numScheduler = numSched;
+        joiners = new FiberJoiners;
+    }
+
+    void schedule(size_t from, int wake) nothrow {
+        wakeFd = wake;
+        scheds[numScheduler].queue.push(this);
+        if (from != numScheduler) {
+            notifyEventloop(numScheduler);
+        }
     }
 
     static size_t flsAlloc() nothrow {
@@ -451,11 +456,18 @@ struct TimedFiber {
     }
 }
 
+class SocketBlock {
+    size_t fastPathSkip;
+    size_t fastPathSkipAck;
+    bool registered;
+    FiberExt current;
+}
+
 shared SchedulerBlock[] scheds;
 
 enum MAX_THREADPOOL_SIZE = 100;
 FiberExt currentFiber;
-__gshared Map!(SOCKET, FiberExt) ioWaiters = new Map!(SOCKET, FiberExt); // mapping of sockets to awaiting fiber
+__gshared Map!(SOCKET, SocketBlock) ioWaiters = new Map!(SOCKET, SocketBlock); // mapping of sockets to awaiting fiber
 __gshared Map!(int, FiberExt) fileWaiters = new Map!(int, FiberExt); // mapping of 'fd's to awaiting fiber, actually keyed by -fd to differ from SOCKET-s
 __gshared PTP_POOL threadPool; // for synchronious syscalls
 __gshared TP_CALLBACK_ENVIRON_V3 environ; // callback environment for the pool
@@ -525,7 +537,7 @@ public Task go(void delegate() func) @trusted nothrow {
     logf("Assigned %x -> %d scheduler", cast(void*)f, choice);
     f.schedule(choice, WAKE_TRIGGER);
     notifyEventloop(choice);
-    return Task(f);
+    return Task(f.joiners);
 }
 
 /// Convenience overload for goOnSameThread that accepts functions 
@@ -543,7 +555,7 @@ public Task goOnSameThread(void delegate() func) nothrow @trusted {
     logf("Assigned %x -> %d / %d scheduler", cast(void*)f, choice, scheds.length);
     f.schedule(choice, WAKE_TRIGGER);
     notifyEventloop(choice);
-    return Task(f);
+    return Task(f.joiners);
 }
 
 /// Convenience overload for goOnAllThreads that accepts functions 
@@ -575,7 +587,9 @@ package(photon) void schedulerEntry(size_t n)
             }
         }
         logf("Fiber %s terminated", cast(void*)f);
-        f.wakeUpJoiners(n);
+        auto joiners = f.joiners;
+        destroy(f);
+        joiners.wakeUpJoiners(n);
     }
     // TODO: handle NUMA case
     //wenforce(SetThreadAffinityMask(GetCurrentThread(), cast(size_t)(1L<<n)) != 0, "failed to set affinity");
@@ -603,7 +617,7 @@ package(photon) void schedulerEntry(size_t n)
                     }
                 }
                 catch (Exception e) {
-                    f.thr = e;
+                    f.joiners.thr = e;
                     onTermination(f);
                 }
                 catch (Throwable e) {
@@ -637,15 +651,13 @@ void processEventsEntry(size_t n, Duration wait) {
             }
             else {
                 SOCKET sock = cast(SOCKET)e.lpCompletionKey;
-                if (sock !in ioWaiters) {
-                    continue;
-                }
-                fiber = ioWaiters[sock];
+                auto w = ioWaiters[sock];
+                fiber = w.current;
                 logf("socket done socket=%d bytes=%d fast = %s", e.lpCompletionKey, 
-                    cast(int)e.dwNumberOfBytesTransferred, fiber.fastPathSkip != fiber.fastPathSkipAck);
+                    cast(int)e.dwNumberOfBytesTransferred, w.fastPathSkip != w.fastPathSkipAck);
                 // handle cases where data was available right away
-                if (fiber.fastPathSkip != fiber.fastPathSkipAck) {
-                    fiber.fastPathSkipAck++;
+                if (w.fastPathSkip != w.fastPathSkipAck) {
+                    w.fastPathSkipAck++;
                     continue;
                 }
                 fiber.bytesTransfered = cast(int)e.dwNumberOfBytesTransferred;
@@ -925,13 +937,18 @@ extern(Windows) int recv(SOCKET s, void* buf, int len, int flags) {
     WSABUF wsabuf = WSABUF(cast(uint)len, buf);
     uint received = 0;
     if (s !in ioWaiters) {
-        registerSocket(s);
+        ioWaiters[s] = new SocketBlock;
     }
-    ioWaiters[s] = currentFiber;
+    auto w = ioWaiters[s];
+    if (w.registered == false) {
+        registerSocket(s);
+        w.registered = true;
+    }
+    w.current = currentFiber;
     int ret = WSARecv(s, &wsabuf, 1, &received, cast(uint*)&flags, cast(LPWSAOVERLAPPED)&overlapped, null);
     logf("Got recv %d", ret);
     if (ret >= 0 && received > 0) {
-        currentFiber.fastPathSkip++;
+        w.fastPathSkip++;
         return received;
     }
     else {
@@ -952,27 +969,32 @@ public int recvWithTimeout(SOCKET s, void* buf, int len, int flags, Duration tim
     WSABUF wsabuf = WSABUF(cast(uint)len, buf);
     FiberExt fiber = currentFiber;
     if (s !in ioWaiters) {
-        registerSocket(s);
+        ioWaiters[s] = new SocketBlock;
     }
-    ioWaiters[s] = fiber;
+    auto w = ioWaiters[s];
+    if (w.registered == false) {
+        registerSocket(s);
+        w.registered = true;
+    }
+    w.current = currentFiber;
     auto entry = timerEntry(&fiber, timeout);
     timeQueue.insert(&entry);
     uint received = 0;
     int ret = WSARecv(s, &wsabuf, 1, &received, cast(uint*)&flags, cast(LPWSAOVERLAPPED)&overlapped, null);
     logf("Got recv %d", ret);
-    if (ret >= 0) {
+    if (ret >= 0 && received > 0) {
         timeQueue.cancel(&entry);
-        currentFiber.fastPathSkip++;
+        w.fastPathSkip++;
         return received;
     }
     else {
         auto lastError = GetLastError();
         logf("Last error = %d", lastError);
-        if (lastError == ERROR_IO_PENDING) {
+        if (lastError == ERROR_IO_PENDING || ret == 0) {
             FiberExt.yield();
             if (currentFiber.wakeFd == WAKE_TIMER) {
                 CancelIoEx(cast(HANDLE)s, &overlapped);
-                currentFiber.fastPathSkip++;
+                w.fastPathSkip++;
                 return -2;
             } else {
                 timeQueue.cancel(&entry);
@@ -988,20 +1010,25 @@ extern(Windows) int send(SOCKET s, void* buf, int len, int flags) {
     OVERLAPPED overlapped;
     WSABUF wsabuf = WSABUF(cast(uint)len, buf);
     if (s !in ioWaiters) {
-        registerSocket(s);
+        ioWaiters[s] = new SocketBlock;
     }
-    ioWaiters[s] = currentFiber;
+    auto w = ioWaiters[s];
+    if (w.registered == false) {
+        registerSocket(s);
+        w.registered = true;
+    }
+    w.current = currentFiber;
     uint sent = 0;
     int ret = WSASend(s, &wsabuf, 1, &sent, flags, cast(LPWSAOVERLAPPED)&overlapped, null);
     logf("Get send %d", ret);
-    if (ret >= 0) {
-        currentFiber.fastPathSkip++;
+    if (ret >= 0 && sent > 0) {
+        w.fastPathSkip++;
         return sent;
     }
     else {
         auto lastError = GetLastError();
         logf("Last error = %d", lastError);
-        if (lastError == ERROR_IO_PENDING) {
+        if (lastError == ERROR_IO_PENDING && ret == 0) {
             FiberExt.yield();
             return currentFiber.bytesTransfered;
         }
@@ -1011,7 +1038,7 @@ extern(Windows) int send(SOCKET s, void* buf, int len, int flags) {
 }
 
 extern(Windows) int closesocket(SOCKET s) {
-    ioWaiters.remove(s);
+    if (s in ioWaiters) ioWaiters[s].registered = false;
     return originalCloseSocket(s);
 }
 

--- a/src/photon/windows/core.d
+++ b/src/photon/windows/core.d
@@ -456,18 +456,17 @@ struct TimedFiber {
     }
 }
 
-class SocketBlock {
-    size_t fastPathSkip;
-    size_t fastPathSkipAck;
-    bool registered;
-    FiberExt current;
+struct Overlapped {
+    OVERLAPPED overlapped;
+    FiberExt fiber;
+    int bytes;
 }
 
 shared SchedulerBlock[] scheds;
 
 enum MAX_THREADPOOL_SIZE = 100;
 FiberExt currentFiber;
-__gshared Map!(SOCKET, SocketBlock) ioWaiters = new Map!(SOCKET, SocketBlock); // mapping of sockets to awaiting fiber
+__gshared Map!(SOCKET, bool) ioWaiters = new Map!(SOCKET, bool); // mapping of sockets to awaiting fiber
 __gshared Map!(int, FiberExt) fileWaiters = new Map!(int, FiberExt); // mapping of 'fd's to awaiting fiber, actually keyed by -fd to differ from SOCKET-s
 __gshared PTP_POOL threadPool; // for synchronious syscalls
 __gshared TP_CALLBACK_ENVIRON_V3 environ; // callback environment for the pool
@@ -651,16 +650,14 @@ void processEventsEntry(size_t n, Duration wait) {
             }
             else {
                 SOCKET sock = cast(SOCKET)e.lpCompletionKey;
-                auto w = ioWaiters[sock];
-                fiber = w.current;
-                logf("socket done socket=%d bytes=%d fast = %s", e.lpCompletionKey, 
-                    cast(int)e.dwNumberOfBytesTransferred, w.fastPathSkip != w.fastPathSkipAck);
-                // handle cases where data was available right away
-                if (w.fastPathSkip != w.fastPathSkipAck) {
-                    w.fastPathSkipAck++;
+                if (sock !in ioWaiters) {
                     continue;
                 }
-                fiber.bytesTransfered = cast(int)e.dwNumberOfBytesTransferred;
+                auto overlapped = cast(Overlapped*)e.lpOverlapped;
+                logf("socket done socket=%d bytes=%d", e.lpCompletionKey, 
+                    cast(int)e.dwNumberOfBytesTransferred);
+                overlapped.bytes = cast(int)e.dwNumberOfBytesTransferred;
+                fiber = overlapped.fiber;
             }
             fiber.schedule(n, WAKE_TRIGGER);
         }
@@ -923,6 +920,7 @@ extern(Windows) SOCKET accept(SOCKET s, sockaddr* addr, LPINT addrlen) {
 }
 
 void registerSocket(SOCKET s) {
+    ioWaiters[s] = true;
     HANDLE port = cast(HANDLE)scheds[currentFiber.numScheduler].iocp;
     wenforce(CreateIoCompletionPort(cast(void*)s, port, cast(size_t)s, 0) == port, "failed to register I/O completion");
 }
@@ -933,30 +931,27 @@ void registerFile(int fd, HANDLE h) {
 }
 
 extern(Windows) int recv(SOCKET s, void* buf, int len, int flags) {
-    OVERLAPPED overlapped;
+    Overlapped* overlapped = cast(Overlapped*)calloc(1, Overlapped.sizeof);
+    scope(exit) free(overlapped);
+    overlapped.fiber = currentFiber;
     WSABUF wsabuf = WSABUF(cast(uint)len, buf);
     uint received = 0;
     if (s !in ioWaiters) {
-        ioWaiters[s] = new SocketBlock;
-    }
-    auto w = ioWaiters[s];
-    if (w.registered == false) {
         registerSocket(s);
-        w.registered = true;
     }
-    w.current = currentFiber;
-    int ret = WSARecv(s, &wsabuf, 1, &received, cast(uint*)&flags, cast(LPWSAOVERLAPPED)&overlapped, null);
+    
+    int ret = WSARecv(s, &wsabuf, 1, &received, cast(uint*)&flags, cast(LPWSAOVERLAPPED)overlapped, null);
     logf("Got recv %d", ret);
     if (ret >= 0 && received > 0) {
-        w.fastPathSkip++;
-        return received;
+        FiberExt.yield();
+        return overlapped.bytes;
     }
     else {
         auto lastError = GetLastError();
         logf("Last error = %d", lastError);
         if (lastError == ERROR_IO_PENDING || ret == 0) {
             FiberExt.yield();
-            return currentFiber.bytesTransfered;
+            return overlapped.bytes;
         }
         else
             return ret;
@@ -965,27 +960,23 @@ extern(Windows) int recv(SOCKET s, void* buf, int len, int flags) {
 
 public int recvWithTimeout(SOCKET s, void* buf, int len, int flags, Duration timeout) {
     if (timeout == Duration.max) return recv(s, buf, len, flags);
-    OVERLAPPED overlapped;
+    Overlapped* overlapped = cast(Overlapped*)calloc(1, Overlapped.sizeof);
+    scope(exit) free(overlapped);
+    overlapped.fiber = currentFiber;
     WSABUF wsabuf = WSABUF(cast(uint)len, buf);
     FiberExt fiber = currentFiber;
     if (s !in ioWaiters) {
-        ioWaiters[s] = new SocketBlock;
-    }
-    auto w = ioWaiters[s];
-    if (w.registered == false) {
         registerSocket(s);
-        w.registered = true;
     }
-    w.current = currentFiber;
     auto entry = timerEntry(&fiber, timeout);
     timeQueue.insert(&entry);
     uint received = 0;
-    int ret = WSARecv(s, &wsabuf, 1, &received, cast(uint*)&flags, cast(LPWSAOVERLAPPED)&overlapped, null);
+    int ret = WSARecv(s, &wsabuf, 1, &received, cast(uint*)&flags, cast(LPWSAOVERLAPPED)overlapped, null);
     logf("Got recv %d", ret);
     if (ret >= 0 && received > 0) {
         timeQueue.cancel(&entry);
-        w.fastPathSkip++;
-        return received;
+        FiberExt.yield();
+        return overlapped.bytes;
     }
     else {
         auto lastError = GetLastError();
@@ -993,13 +984,13 @@ public int recvWithTimeout(SOCKET s, void* buf, int len, int flags, Duration tim
         if (lastError == ERROR_IO_PENDING || ret == 0) {
             FiberExt.yield();
             if (currentFiber.wakeFd == WAKE_TIMER) {
-                CancelIoEx(cast(HANDLE)s, &overlapped);
-                w.fastPathSkip++;
+                CancelIoEx(cast(HANDLE)s, cast(LPOVERLAPPED)overlapped);
+                FiberExt.yield();
                 return -2;
             } else {
                 timeQueue.cancel(&entry);
             }
-            return currentFiber.bytesTransfered;
+            return overlapped.bytes;
         }
         else
             return ret;
@@ -1007,30 +998,26 @@ public int recvWithTimeout(SOCKET s, void* buf, int len, int flags, Duration tim
 }
 
 extern(Windows) int send(SOCKET s, void* buf, int len, int flags) {
-    OVERLAPPED overlapped;
+    Overlapped* overlapped = cast(Overlapped*)calloc(1, Overlapped.sizeof);
+    scope(exit) free(overlapped);
+    overlapped.fiber = currentFiber;
     WSABUF wsabuf = WSABUF(cast(uint)len, buf);
     if (s !in ioWaiters) {
-        ioWaiters[s] = new SocketBlock;
-    }
-    auto w = ioWaiters[s];
-    if (w.registered == false) {
         registerSocket(s);
-        w.registered = true;
     }
-    w.current = currentFiber;
     uint sent = 0;
-    int ret = WSASend(s, &wsabuf, 1, &sent, flags, cast(LPWSAOVERLAPPED)&overlapped, null);
+    int ret = WSASend(s, &wsabuf, 1, &sent, flags, cast(LPWSAOVERLAPPED)overlapped, null);
     logf("Get send %d", ret);
     if (ret >= 0 && sent > 0) {
-        w.fastPathSkip++;
-        return sent;
+        FiberExt.yield();
+        return overlapped.bytes;
     }
     else {
         auto lastError = GetLastError();
         logf("Last error = %d", lastError);
-        if (lastError == ERROR_IO_PENDING && ret == 0) {
+        if (lastError == ERROR_IO_PENDING || ret == 0) {
             FiberExt.yield();
-            return currentFiber.bytesTransfered;
+            return overlapped.bytes;
         }
         else 
             return ret;
@@ -1038,7 +1025,7 @@ extern(Windows) int send(SOCKET s, void* buf, int len, int flags) {
 }
 
 extern(Windows) int closesocket(SOCKET s) {
-    if (s in ioWaiters) ioWaiters[s].registered = false;
+    ioWaiters.remove(s);
     return originalCloseSocket(s);
 }
 


### PR DESCRIPTION
Also destroy fibers on termination otherwise the cleanup is too delayed.

This fixes #66 and also keeps track of memory used by fibers