### PR TITLE
Handle closed channels to avoid blocking, a start on pseudorandom wake

### DIFF
--- a/examples/await.d
+++ b/examples/await.d
@@ -12,7 +12,7 @@
 	"name": "channels"
 }
 +/
-module tests.await;
+module examples.await;
 
 import std.stdio, std.datetime;
 import photon;

--- a/examples/select2.d
+++ b/examples/select2.d
@@ -1,0 +1,45 @@
+#!/usr/bin/env dub
+/+ dub.json:
+    {
+	"authors": [
+		"Dmitry Olshansky"
+	],
+	"copyright": "Copyright © 2026, Dmitry Olshansky",
+	"dependencies": {
+		"photon": { "path": ".." }
+	},
+    "description": "A test for select on closed channels",
+	"license": "BOOST",
+	"name": "select2"
+}
++/
+module photon.examples.select2;
+
+import std.range, std.datetime, std.stdio;
+
+import photon;
+
+void main() {
+    initPhoton();
+    auto first = channel!(int)(2);
+    auto second = channel!(int)(2);
+    first.close();
+    second.close();
+    go({
+        bool[2] channels;
+        // test pseudo random selection on closed channels
+        while (channels != [true, true]) {
+            select(
+                first, {
+                    channels[0] = true;
+                    assert(first.empty);
+                },
+                second, {
+                    channels[1] = true;
+                    assert(second.empty);
+                }
+            );
+        }
+    });
+    runScheduler();
+}

--- a/src/photon/package.d
+++ b/src/photon/package.d
@@ -598,6 +598,10 @@ public:
         buf.close();
     }
 
+    bool closed() shared {
+        return buf_.closed;
+    }
+
     /++
         Part of InputRange contract - checks if there is an item in the queue.
         Returns: `true` if channel is closed and its buffer is exhausted.
@@ -700,8 +704,11 @@ if (
     (Args.length % 2 == 0 && allSatisfy!(isChannel, Even!Args) && allSatisfy!(isHandler, Odd!Args)) ||
     (allSatisfy!(isChannel, Even!(Args[0..$-1])) && allSatisfy!(isHandler, Odd!(Args[0..$-1])) && isHandler!(Args[$-1]))
 ) {
+    import std.random;
     void delegate()[args.length / 2] handlers = void;
     Event*[args.length/2] events = void;
+    size_t[args.length/2] ready;
+    size_t readyCount=0;
     alias paired = args[0 .. args.length - args.length % 2];
     static foreach (i, v; paired) {
         static if(i % 2 == 0) {
@@ -717,8 +724,12 @@ if (
         }
     }
     foreach (i, channel; Even!(paired)) {
-        if (channel.buf.readyToRead())
-            return handlers[i]();
+        if (channel.buf.readyToRead() || channel.buf.closed) {
+            ready[readyCount++] = i;
+        }
+    }
+    if (readyCount > 0) {
+        return handlers[choice(ready[0..readyCount])]();
     }
     static if (args.length % 2) {
         return args[$-1]();
@@ -729,7 +740,7 @@ if (
         switch(n) {
             static foreach (i, channel; Even!(paired)) {
                 case i:
-                    if (channel.buf.readyToRead())
+                    if (channel.buf.readyToRead() || channel.buf.closed)
                         return handlers[n]();
                     break L_dispatch;
             }

--- a/src/photon/windows/core.d
+++ b/src/photon/windows/core.d
@@ -307,8 +307,8 @@ if (allSatisfy!(isAwaitable, Awaitable)) {
     auto box = cast(MultiAwaitBox*)calloc(1, MultiAwaitBox.sizeof);
     box.refCount = args.length;
     box.fiber = cast(shared)currentFiber;
-    foreach (int i, ref v; args) {
-        v.registerForWaitAny(i, box);
+    foreach (i, ref v; args) {
+        v.registerForWaitAny(cast(int)i, box);
     }
     FiberExt.yield();
     return currentFiber.wakeFd;


### PR DESCRIPTION
This solves issue #70. In Windows version it seems like pseudo random wake ups are working, Linux at the moment will only do so if events are already "ready" and not if it had to poll them.