### PR TITLE
Switch to Overlapped struct for file I/O too, fix double schedule

### DIFF
--- a/examples/io.d
+++ b/examples/io.d
@@ -13,16 +13,67 @@
 	"name": "io"
 }
 +/
+import std.stdio;
+import photon;
+
 version(Windows) {
+import std.file : tempDir;
+import std.path : buildPath;
+import std.random;
+import std.string;
+import std.conv;
 
 void main() {
+    initPhoton();
+    goOnSameThread({
+        try {
+            writeln("Starting to read/write");
+            read_write(0);
+            writeln("Done read/write");
+        } catch (Throwable t) {
+            writeln(t);
+        }
+    });
+    goOnSameThread({
+        writeln("Starting to read/write #2");
+        read_write(1);
+        writeln("Done read/write #2");
+    });
+    goOnSameThread({
+        writeln("Starting to read/write #3");
+        read_write(2);
+        writeln("Done read/write #3");
+    });
+    runScheduler();
+}
 
+void read_write(int id) {
+    auto dir = tempDir;
+    auto name = "read_write_ " ~ to!string(id) ~ "_" ~ to!string(uniform!ulong) ~ ".tmp";
+    auto path = buildPath(dir, name);
+    int handle = open(path.toStringz, O_RDWR | O_CREAT, octal!777);
+    scope(exit) std.file.remove(path);
+    assert(handle >= 0);
+    scope(exit) close(handle);
+    enum SIZE = 1<<20;
+    ubyte[] data = new ubyte[SIZE];
+    data[] = 0x55;
+    int ret = ftruncate(handle, SIZE);
+    assert(ret >= 0);
+    foreach (_; 0..100) {
+        ret = cast(int)pwrite(handle, data.ptr, data.length, 0);
+        assert(ret >= 0);
+        data[] = 0xAA;
+        ret = cast(int)pread(handle, data.ptr, data.length, 0);
+        assert(ret >= 0);
+        foreach (i; 0..data.length) {
+            assert(data[i] == 0x55);
+        }
+    }
 }
 
 } else:
-import std.stdio;
 import core.sys.posix.unistd;
-import photon;
 
 void read_a_lot() {
     ubyte[] buf = new ubyte[2^^20];

--- a/src/photon/windows/core.d
+++ b/src/photon/windows/core.d
@@ -333,7 +333,6 @@ class FiberExt : Fiber {
     FiberExt next;
     FiberExt back;
     uint numScheduler;
-    int bytesTransfered;
     int wakeFd;
     FiberJoiners joiners;
     struct FlsEntry {
@@ -407,7 +406,7 @@ struct TimedFiber {
 
 struct Overlapped {
     OVERLAPPED overlapped;
-    FiberExt fiber;
+    shared FiberExt fiber;
     int bytes;
 }
 
@@ -593,22 +592,14 @@ void processEventsEntry(size_t n, Duration wait) {
                 notify = true;
                 continue; // user event to wake up event loop
             }
-            FiberExt fiber;
-            if (cast(long)e.lpCompletionKey < 0) {
-                fiber = fileWaiters[cast(int)-cast(long)e.lpCompletionKey];
-            }
-            else {
-                SOCKET sock = cast(SOCKET)e.lpCompletionKey;
-                if (sock !in ioWaiters) {
-                    continue;
-                }
-                auto overlapped = cast(Overlapped*)e.lpOverlapped;
+            auto overlapped = cast(Overlapped*)e.lpOverlapped;
+            FiberExt fiber = cast(FiberExt)steal(overlapped.fiber);
+            if (fiber !is null) {
                 logf("socket done socket=%d bytes=%d", e.lpCompletionKey, 
                     cast(int)e.dwNumberOfBytesTransferred);
                 overlapped.bytes = cast(int)e.dwNumberOfBytesTransferred;
-                fiber = overlapped.fiber;
+                fiber.schedule(n, WAKE_TRIGGER);
             }
-            fiber.schedule(n, WAKE_TRIGGER);
         }
         if (count < MAX_COMPLETIONS || notify) break;
     }
@@ -754,9 +745,11 @@ public @trusted nothrow {
     extern(C) ptrdiff_t pwrite(int fd, const(void) *buf, size_t count, ulong offset) {
         static HANDLE ev = INVALID_HANDLE_VALUE;
         auto h = fromFd(fd);
-        OVERLAPPED overlapped;
-        overlapped.Offset = offset & 0xffff_ffff;
-        overlapped.OffsetHigh = offset >> 32;
+        Overlapped* overlapped = cast(Overlapped*)calloc(1, Overlapped.sizeof);
+        scope(exit) free(overlapped);
+        overlapped.overlapped.Offset = offset & 0xffff_ffff;
+        overlapped.overlapped.OffsetHigh = offset >> 32;
+        overlapped.fiber = cast(shared)currentFiber;
         if (currentFiber) {
             if (-fd !in fileWaiters) {
                 try {
@@ -770,14 +763,14 @@ public @trusted nothrow {
             if (ev == INVALID_HANDLE_VALUE) {
                 ev = cast(HANDLE)CreateEventA(null, FALSE, FALSE, null);
             }
-            overlapped.hEvent = ev;
+            overlapped.overlapped.hEvent = ev;
         }
         if (currentFiber) {
-            if (!WriteFileEx(h, buf, cast(uint)count, &overlapped, null)) return -1;
+            if (!WriteFileEx(h, buf, cast(uint)count, cast(OVERLAPPED*)overlapped, null)) return -1;
             FiberExt.yield();
-            return currentFiber.bytesTransfered;
+            return overlapped.bytes;
         } else {
-            if (!WriteFile(h, buf, cast(uint)count, null, &overlapped) && GetLastError() != ERROR_IO_PENDING) {
+            if (!WriteFile(h, buf, cast(uint)count, null, cast(OVERLAPPED*)overlapped) && GetLastError() != ERROR_IO_PENDING) {
                 return -1;
             }
             WaitForSingleObject(ev, INFINITE);
@@ -788,9 +781,11 @@ public @trusted nothrow {
     extern(C) ptrdiff_t pread(int fd, void *buf, size_t count, ulong offset) {
         static HANDLE ev = INVALID_HANDLE_VALUE;
         auto h = fromFd(fd);
-        OVERLAPPED overlapped;
-        overlapped.Offset = offset & 0xffff_ffff;
-        overlapped.OffsetHigh = offset >> 32;
+        Overlapped* overlapped = cast(Overlapped*)calloc(1, Overlapped.sizeof);
+        scope(exit) free(overlapped);
+        overlapped.overlapped.Offset = offset & 0xffff_ffff;
+        overlapped.overlapped.OffsetHigh = offset >> 32;
+        overlapped.fiber = cast(shared)currentFiber;
         if (currentFiber) {
             if (-fd !in fileWaiters) {
                 try {
@@ -804,14 +799,14 @@ public @trusted nothrow {
             if (ev == INVALID_HANDLE_VALUE) {
                 ev = cast(HANDLE)CreateEventA(null, FALSE, FALSE, null);
             }
-            overlapped.hEvent = ev;
+            overlapped.overlapped.hEvent = ev;
         }
         if (currentFiber) {
-            if (!ReadFileEx(h, buf, cast(uint)count, &overlapped, null)) return -1;
+            if (!ReadFileEx(h, buf, cast(uint)count, cast(OVERLAPPED*)overlapped, null)) return -1;
             FiberExt.yield();
-            return currentFiber.bytesTransfered;
+            return overlapped.bytes;
         } else {
-            if (!ReadFile(h, buf, cast(uint)count, null, &overlapped) && GetLastError() != ERROR_IO_PENDING) return -1;
+            if (!ReadFile(h, buf, cast(uint)count, null, cast(OVERLAPPED*)overlapped) && GetLastError() != ERROR_IO_PENDING) return -1;
             WaitForSingleObject(ev, INFINITE);
             return count;
         }
@@ -882,7 +877,7 @@ void registerFile(int fd, HANDLE h) {
 extern(Windows) int recv(SOCKET s, void* buf, int len, int flags) {
     Overlapped* overlapped = cast(Overlapped*)calloc(1, Overlapped.sizeof);
     scope(exit) free(overlapped);
-    overlapped.fiber = currentFiber;
+    overlapped.fiber = cast(shared)currentFiber;
     WSABUF wsabuf = WSABUF(cast(uint)len, buf);
     uint received = 0;
     if (s !in ioWaiters) {
@@ -911,13 +906,12 @@ public int recvWithTimeout(SOCKET s, void* buf, int len, int flags, Duration tim
     if (timeout == Duration.max) return recv(s, buf, len, flags);
     Overlapped* overlapped = cast(Overlapped*)calloc(1, Overlapped.sizeof);
     scope(exit) free(overlapped);
-    overlapped.fiber = currentFiber;
+    overlapped.fiber = cast(shared)currentFiber;
     WSABUF wsabuf = WSABUF(cast(uint)len, buf);
-    FiberExt fiber = currentFiber;
     if (s !in ioWaiters) {
         registerSocket(s);
     }
-    auto entry = timerEntry(&fiber, timeout);
+    auto entry = timerEntry(cast(FiberExt*)&overlapped.fiber, timeout);
     timeQueue.insert(&entry);
     uint received = 0;
     int ret = WSARecv(s, &wsabuf, 1, &received, cast(uint*)&flags, cast(LPWSAOVERLAPPED)overlapped, null);
@@ -949,7 +943,7 @@ public int recvWithTimeout(SOCKET s, void* buf, int len, int flags, Duration tim
 extern(Windows) int send(SOCKET s, void* buf, int len, int flags) {
     Overlapped* overlapped = cast(Overlapped*)calloc(1, Overlapped.sizeof);
     scope(exit) free(overlapped);
-    overlapped.fiber = currentFiber;
+    overlapped.fiber = cast(shared)currentFiber;
     WSABUF wsabuf = WSABUF(cast(uint)len, buf);
     if (s !in ioWaiters) {
         registerSocket(s);

--- a/src/photon/windows/core.d
+++ b/src/photon/windows/core.d
@@ -595,8 +595,7 @@ void processEventsEntry(size_t n, Duration wait) {
             auto overlapped = cast(Overlapped*)e.lpOverlapped;
             FiberExt fiber = cast(FiberExt)steal(overlapped.fiber);
             if (fiber !is null) {
-                logf("socket done socket=%d bytes=%d", e.lpCompletionKey, 
-                    cast(int)e.dwNumberOfBytesTransferred);
+                logf("i/o done completionKey=%d bytes=%d", e.lpCompletionKey, e.dwNumberOfBytesTransferred);
                 overlapped.bytes = cast(int)e.dwNumberOfBytesTransferred;
                 fiber.schedule(n, WAKE_TRIGGER);
             }
@@ -765,14 +764,13 @@ public @trusted nothrow {
             }
             overlapped.overlapped.hEvent = ev;
         }
+        if (!WriteFile(h, buf, cast(uint)count, null, cast(OVERLAPPED*)overlapped) && GetLastError() != ERROR_IO_PENDING) {
+            return -1;
+        }
         if (currentFiber) {
-            if (!WriteFileEx(h, buf, cast(uint)count, cast(OVERLAPPED*)overlapped, null)) return -1;
             FiberExt.yield();
             return overlapped.bytes;
         } else {
-            if (!WriteFile(h, buf, cast(uint)count, null, cast(OVERLAPPED*)overlapped) && GetLastError() != ERROR_IO_PENDING) {
-                return -1;
-            }
             WaitForSingleObject(ev, INFINITE);
             return count;
         }
@@ -801,12 +799,11 @@ public @trusted nothrow {
             }
             overlapped.overlapped.hEvent = ev;
         }
+        if (!ReadFile(h, buf, cast(uint)count, null, cast(OVERLAPPED*)overlapped) && GetLastError() != ERROR_IO_PENDING) return -1;
         if (currentFiber) {
-            if (!ReadFileEx(h, buf, cast(uint)count, cast(OVERLAPPED*)overlapped, null)) return -1;
             FiberExt.yield();
             return overlapped.bytes;
         } else {
-            if (!ReadFile(h, buf, cast(uint)count, null, cast(OVERLAPPED*)overlapped) && GetLastError() != ERROR_IO_PENDING) return -1;
             WaitForSingleObject(ev, INFINITE);
             return count;
         }


### PR DESCRIPTION
This should fix potential double scheduling for recvWithTimeout and switch to Overlapped based I/O